### PR TITLE
security: pin requirements.txt to exact versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask~=3.0
-pandas~=2.0
-openpyxl~=3.1
+flask==3.0.3
+pandas==2.2.3
+openpyxl==3.1.5


### PR DESCRIPTION
## Summary

`requirements.txt` previously used the `~=` compatibility specifier:

```
flask~=3.0
pandas~=2.0
openpyxl~=3.1
```

`~=` allows any minor-or-patch release at or above the listed version, so a compromised patch release of any of these packages would be pulled in automatically on the next deploy. Exact `==` pins make builds reproducible and gives the maintainer explicit control over dependency bumps (Dependabot/Renovate can still open PRs to move the pins forward).

## Change

```
flask==3.0.3
pandas==2.2.3
openpyxl==3.1.5
```

The chosen versions are the latest stable releases in each package's current series at the time of this review.

## Test plan
- [ ] `pip install -r requirements.txt` succeeds
- [ ] `python app.py` starts and serves `/` without regressions

Severity: LOW
Part of the security review tracked in `security-review-infralens.md`.