### PR TITLE
security: pin GitHub Actions to commit SHAs (refs #47)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: main
           path: main
 
       - name: Checkout dev branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: dev
           path: dev
@@ -38,7 +38,7 @@ jobs:
           rm -rf _site/.git _site/dev/.git _site/.github _site/dev/.github
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: _site
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5


### PR DESCRIPTION
## Summary

Pins the three third-party actions used in `.github/workflows/pages.yml` to full commit SHAs (with trailing `# vX.Y.Z` comments), instead of floating major tags.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2` |
| `actions/upload-pages-artifact` | `@v3` | `@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1` |
| `actions/deploy-pages` | `@v4` | `@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5` |

## Why

If an upstream tag is force-moved to a compromised commit, the next Pages build would run that compromised code under a token with `pages: write` and `id-token: write`. Full-SHA pinning (recommended by GitHub's own hardening guide) eliminates that supply-chain risk; the `# vX.Y.Z` comments keep the human-readable version visible.

## Closes
Refs #47.

## Test plan
- [ ] Dry-run the workflow on `dev` to confirm the pinned SHAs still resolve.
- [ ] Verify the Pages deploy completes after merge.

Severity: **LOW**

---
Opened by automated security review (session `LotRY`).

---
_Generated by [Claude Code](https://claude.ai/code/session_011QACgjzNRiGYjif2Mn3WCg)_