### PR TITLE
fix(security): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: main
           path: main
 
       - name: Checkout dev branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: dev
           path: dev
@@ -38,7 +38,7 @@ jobs:
           rm -rf _site/.git _site/dev/.git _site/.github _site/dev/.github
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: _site
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5


### PR DESCRIPTION
## Summary
Replaces floating major-version tags (`@v4`, `@v3`) with full commit SHAs in `.github/workflows/pages.yml` to mitigate supply-chain risk if a tag is force-moved to a malicious commit.

| Action | Pinned SHA | Tag |
|---|---|---|
| `actions/checkout` | `11bd71901bbe5b1630ceea73d27597364c9af683` | v4.2.2 |
| `actions/upload-pages-artifact` | `56afc609e74202658d3ffba0e8f6dda462b719fa` | v3.0.1 |
| `actions/deploy-pages` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` | v4.0.5 |

Refs issue #47.

## Test plan
- [ ] Confirm Pages workflow runs successfully on push to `main` after merge
- [ ] Verify both `main` and `dev` branches still get deployed

https://claude.ai/code/session_01LgJhkzXY7CK6QQiDiUbc9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01LgJhkzXY7CK6QQiDiUbc9r)_