### PR TITLE
security: pin runtime dependencies to exact versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask~=3.0
-pandas~=2.0
-openpyxl~=3.1
+flask==3.0.3
+pandas==2.2.3
+openpyxl==3.1.5


### PR DESCRIPTION
## Severity
LOW

## File
`requirements.txt`

## Root cause
`flask~=3.0`, `pandas~=2.0`, `openpyxl~=3.1` allow arbitrary minor releases at install time. Builds are non-reproducible; an upstream regression or supply-chain incident on a future minor version is automatically picked up. `~=2.0` for `pandas` in particular spans many years of releases.

## Fix summary
Pin each dependency to a specific tested version:

- `flask==3.0.3`
- `pandas==2.2.3`
- `openpyxl==3.1.5`

These are the latest stable versions of each library at the time of writing and are known to work with the existing code paths (no API surface used by `app.py` has changed across the supported range). Future bumps should land via Dependabot/Renovate PRs that exercise the test suite.

Generated by Claude security review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QbueLXpL2r62wfMwzJ7Bhg)_